### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/HACS_validate.yaml
+++ b/.github/workflows/HACS_validate.yaml
@@ -1,4 +1,6 @@
 name: Validate with HACS
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ReneNulschDE/ha_link2home/security/code-scanning/3](https://github.com/ReneNulschDE/ha_link2home/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow, either at the root level (to apply to all jobs) or at the job level (to apply only to the specific job). The minimal required permission for most validation workflows is `contents: read`, which allows the workflow to read repository contents but not to write or modify anything. This change should be made at the top level of the workflow file, immediately after the `name` field and before the `on` field, or within the `validate` job if you want to scope it more narrowly. Since there is only one job, adding it at the root is simplest and most effective.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
